### PR TITLE
Add a ROS package.xml file to allow building in a catkin workspace

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package>
+  <name>sitl_gazebo</name>
+  <version>0.1.0</version>
+  <description>The sitl_gazebo package</description>
+  <maintainer email="info@dronecode.org">Drone Code</maintainer>
+  <license>TODO</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <build_depend>pkg-config</build_depend>
+  <build_depend>opencv2</build_depend>
+  <build_depend>eigen3</build_depend>
+  <build_depend>protobuf</build_depend>
+  <build_depend>boost</build_depend>
+  <build_depend>gazebo6</build_depend>
+  <build_depend>cmake_modules</build_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <export>
+  </export>
+</package>


### PR DESCRIPTION
With this file in place you can build in a catkin workspace.  This allows for more integration scenarios like running Gazebo with ROS.